### PR TITLE
Support for Run directory when using setuid

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,11 +1,11 @@
 ##
-# = class: jetty::install - The installation of jetty's stuff 
+# = class: jetty::install - The installation of jetty's stuff
 class jetty::install inherits jetty {
 
   $_jetty_home             = "${jetty::root}/jetty"
   $_jetty_tmp              = "${_jetty_home}/tmp"
   $_jetty_logs             = "${_jetty_home}/logs"
-  $_jetty_run             = "${_jetty_home}/run"
+  $_jetty_run              = "${_jetty_home}/run"
   $_jetty_sh               = "${_jetty_home}/bin/jetty.sh"
   $_download_directory     = "jetty-distribution-${jetty::version}"
   $_download_file_name     = "${_download_directory}.${jetty::archive_type}"
@@ -58,8 +58,8 @@ class jetty::install inherits jetty {
 
   file { $_jetty_run:
     ensure => directory,
-    owner => $::jetty::user,
-    group => $::jetty::group,
+    owner  => $::jetty::user,
+    group  => $::jetty::group,
   } ->
   file { '/etc/init.d/jetty':
     ensure => link,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,7 @@ class jetty::install inherits jetty {
   $_jetty_home             = "${jetty::root}/jetty"
   $_jetty_tmp              = "${_jetty_home}/tmp"
   $_jetty_logs             = "${_jetty_home}/logs"
+  $_jetty_run             = "${_jetty_home}/run"
   $_jetty_sh               = "${_jetty_home}/bin/jetty.sh"
   $_download_directory     = "jetty-distribution-${jetty::version}"
   $_download_file_name     = "${_download_directory}.${jetty::archive_type}"
@@ -55,6 +56,11 @@ class jetty::install inherits jetty {
     require         => User[$::jetty::user],
   }
 
+  file { $_jetty_run:
+    ensure => directory,
+    owner => $::jetty::user,
+    group => $::jetty::group,
+  } ->
   file { '/etc/init.d/jetty':
     ensure => link,
     target => $_jetty_sh,
@@ -65,6 +71,10 @@ class jetty::install inherits jetty {
   file { '/var/log/jetty':
     ensure => link,
     target => $_jetty_logs,
+  } ->
+  file { '/var/run/jetty':
+    ensure => link,
+    target => $_jetty_run,
   } ->
   file { $_jetty_tmp:
     ensure => directory,

--- a/templates/jetty-defaults.erb
+++ b/templates/jetty-defaults.erb
@@ -2,6 +2,7 @@ JETTY_HOME="<%= @root %>/jetty"
 JETTY_BASE="<%= @base %>"
 JETTY_USER="<%= @user %>"
 JETTY_PID="<%= @root %>/jetty/jetty.pid"
+JETTY_RUN="<%= @root %>/jetty/run"
 JETTY_SHELL="/bin/sh"
 <% if @jetty_arguments %>
 JETTY_ARGS="<%= @jetty_arguments %>"

--- a/templates/jetty-defaults.erb
+++ b/templates/jetty-defaults.erb
@@ -1,6 +1,7 @@
 JETTY_HOME="<%= @root %>/jetty"
 JETTY_BASE="<%= @base %>"
 JETTY_USER="<%= @user %>"
+JETTY_PID="<%= @root %>/jetty/jetty.pid"
 JETTY_SHELL="/bin/sh"
 <% if @jetty_arguments %>
 JETTY_ARGS="<%= @jetty_arguments %>"

--- a/templates/jetty-defaults.erb
+++ b/templates/jetty-defaults.erb
@@ -1,8 +1,6 @@
 JETTY_HOME="<%= @root %>/jetty"
 JETTY_BASE="<%= @base %>"
 JETTY_USER="<%= @user %>"
-JETTY_PID="<%= @root %>/jetty/jetty.pid"
-JETTY_RUN="<%= @root %>/jetty/run"
 JETTY_SHELL="/bin/sh"
 <% if @jetty_arguments %>
 JETTY_ARGS="<%= @jetty_arguments %>"

--- a/templates/start.ini.erb
+++ b/templates/start.ini.erb
@@ -1,17 +1,15 @@
 <% if @configuration.keys.length > 0 %>
-  <%-
-  _modules = @configuration.fetch('modules', [])
-  _options = @configuration.fetch('options', {})
-  %>
+<%-
+_modules = @configuration.fetch('modules', [])
+_options = @configuration.fetch('options', {})
+%>
 --module=home-base-warning
 
-  <% _modules.each do |m| %>
---module=<%= m %>
-  <% end %>
+<% _modules.each do |m| %>
+--module=<%= m %><% end %>
 
-  <% _options.each do |k,v| %>
-<%= k %>=<%= v %>
-  <% end %>
+<% _options.each do |k,v| %>
+<%= k %>=<%= v %><% end %>
 <% end %>
 
 

--- a/templates/start.ini.erb
+++ b/templates/start.ini.erb
@@ -9,10 +9,8 @@
 --module=<%= m %>
   <% end %>
 
-  <% _options.each do |o| %>
-    <% _options.fetch(o, {}).each do |k,v| %>
+  <% _options.each do |k,v| %>
 <%= k %>=<%= v %>
-    <% end %>
   <% end %>
 <% end %>
 

--- a/templates/start.ini.erb
+++ b/templates/start.ini.erb
@@ -6,9 +6,11 @@ _options = @configuration.fetch('options', {})
 --module=home-base-warning
 <% _modules.each do |m| %>
 --module=<%= m %>
-<% _options.fetch(m, {}).each do |k,v| %>
-<%= k %>=<%= v %>
 <% end %>
+
+<% _options.each do |o| %>
+<% _options.fetch(o, {}).each do |k,v| %>
+<%= k %>=<%= v %>
 <% end %>
 <% end %>
 

--- a/templates/start.ini.erb
+++ b/templates/start.ini.erb
@@ -1,16 +1,19 @@
 <% if @configuration.keys.length > 0 %>
-<%-
-_modules = @configuration.fetch('modules', [])
-_options = @configuration.fetch('options', {})
-%>
+  <%-
+  _modules = @configuration.fetch('modules', [])
+  _options = @configuration.fetch('options', {})
+  %>
 --module=home-base-warning
-<% _modules.each do |m| %>
+
+  <% _modules.each do |m| %>
 --module=<%= m %>
+  <% end %>
+
+  <% _options.each do |o| %>
+    <% _options.fetch(o, {}).each do |k,v| %>
+<%= k %>=<%= v %>
+    <% end %>
+  <% end %>
 <% end %>
 
-<% _options.each do |o| %>
-<% _options.fetch(o, {}).each do |k,v| %>
-<%= k %>=<%= v %>
-<% end %>
-<% end %>
 


### PR DESCRIPTION
In the current code, when setting up jetty to run, it puts the default run directory as /var/run/jetty but doesn't chown it for the jetty user.   Follows the model for doing the same process that logging does - makes a simlink to something under the jetty installation directory.  Pull from commit 

39858cf2939f1a4f359ba5623a4fc86a0fa41d5b

Second part, which unfortunately I could not separate out because I was dumb with my branch management is to  change the way the configuration attribute is managed.  Instead of having
`configuration => {
   'modules => {
     http => {
       options => { .... }
    }
  }
}`

It separates the modules from the options allowing for quick disable of a module, while leaving the options in place.  The new form looks like this:

`configuration => {
    modules => [ 'http', 'jstl', .... ]
    options => {
       'jetty.port' => '8081',
       'jetty.ip' => '127.0.0.1',
       ....
    }
}
     `